### PR TITLE
Fix: Use direct link images urls from PHT and END tokens

### DIFF
--- a/src/tokens/IMX.json
+++ b/src/tokens/IMX.json
@@ -125,6 +125,6 @@
         "symbol": "END",
         "decimals": 18,
         "chainId": 13371,
-        "logoURI": "https://imgur.com/fGDfPEc"
+        "logoURI": "https://i.imgur.com/fGDfPEc.png"
       }
 ]

--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -1091,7 +1091,7 @@
     "symbol": "PHT",
     "decimals": 18,
     "chainId": 137,
-    "logoURI": "https://imgur.com/a/ozwVu2d",
+    "logoURI": "https://i.imgur.com/vIX6pTjh.jpg",
     "trending": false
   }
 ]


### PR DESCRIPTION
# Tokens changed

### IMX
- [END](https://explorer.immutable.com/token/0x43D7B1F2E92c620FC45cC81d3818E4620AbaF240)
- **Logo URL**: [`https://i.imgur.com/fGDfPEc.png`](https://i.imgur.com/fGDfPEc.png)

### PoS
- Stablecoin [PHT](https://polygonscan.com/token/0xe75220cB014Dfb2D354bb59be26d7458bB8d0706)
- **Logo URL**: [`https://i.imgur.com/vIX6pTjh.jpg`](https://i.imgur.com/vIX6pTjh.jpg)