### PR TITLE
Add base tokens: cbETH, wstETH, GHO, USDbc, CERE, QUICK

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quickswap-default-token-list",
-  "version": "1.3.83",
+  "version": "1.3.84",
   "description": "◦ The Quickswap default token list",
   "main": "build/quickswap-default.tokenlist.json",
   "scripts": {

--- a/src/tokens/base.json
+++ b/src/tokens/base.json
@@ -32,5 +32,53 @@
     "decimals": 18,
     "chainId": 8453,
     "logoURI": "https://basescan.org/token/images/imgnlabs_64.svg"
+  },
+  {
+    "name": "Coinbase ETH",
+    "address": "0x2Ae3F1Ec7F1F5012CFEab0185bfc7aa3cf0DEc22",
+    "symbol": "cbETH",
+    "decimals": 18,
+    "chainId": 8453,
+    "logoURI": "https://basescan.org/token/images/coinbasecbeth_32.png"
+  },
+  {
+    "name": "Wrapped Liquid Staked ETH",
+    "address": "0xc1CBa3fCea344f92D9239c08C0568f6F2F0ee452",
+    "symbol": "wstETH",
+    "decimals": 18,
+    "chainId": 8453,
+    "logoURI": "https://basescan.org/token/images/wsteth3_32.png"
+  },
+  {
+    "name": "GHO",
+    "address": "0x6Bb7a212910682DCFdbd5BCBb3e28FB4E8da10Ee",
+    "symbol": "GHO",
+    "decimals": 18,
+    "chainId": 8453,
+    "logoURI": "https://etherscan.io/token/images/aavegho_new_32.png"
+  },
+  {
+    "name": "USD Base Coin",
+    "address": "0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA",
+    "symbol": "USDbc",
+    "decimals": 6,
+    "chainId": 8453,
+    "logoURI": "https://basescan.org/token/images/usdbc_ofc_32.png"
+  },
+  {
+    "name": "CERE",
+    "address": "0x9886447Ff4c350f4600E4BF95Db756Bdc629b1cA",
+    "symbol": "CERE",
+    "decimals": 10,
+    "chainId": 8453,
+    "logoURI": "https://etherscan.io/token/images/cerenetwork_32.png"
+  },
+  {
+    "name": "QUICKSWAP",
+    "address": "0x7094c27f342dbadfbbed005b219431595e33b305",
+    "symbol": "QUICK",
+    "decimals": 18,
+    "chainId": 8453,
+    "logoURI": "https://etherscan.io/token/images/quickswapnew_32.png"
   }
 ]

--- a/src/tokens/base.json
+++ b/src/tokens/base.json
@@ -75,7 +75,7 @@
   },
   {
     "name": "QUICKSWAP",
-    "address": "0x7094c27f342dbadfbbed005b219431595e33b305",
+    "address": "0x7094c27f342DBAdfbbeD005b219431595E33b305",
     "symbol": "QUICK",
     "decimals": 18,
     "chainId": 8453,


### PR DESCRIPTION
## Tokens changed

### Coinbase ETH
- Symbol: `cbETH`
- [BaseScan: 0x2Ae3F1Ec7F1F5012CFEab0185bfc7aa3cf0DEc22](https://basescan.org/token/0x2Ae3F1Ec7F1F5012CFEab0185bfc7aa3cf0DEc22)

### Wrapped Liquid Staked ETH
- Symbol: `wstETH`
- [BaseScan: 0xc1CBa3fCea344f92D9239c08C0568f6F2F0ee452](https://basescan.org/token/0xc1CBa3fCea344f92D9239c08C0568f6F2F0ee452)

### GHO
- Symbol: `GHO`
- [Etherscan: 0x6Bb7a212910682DCFdbd5BCBb3e28FB4E8da10Ee](https://basescan.org/token/0x6Bb7a212910682DCFdbd5BCBb3e28FB4E8da10Ee)

### USD Base Coin
- Symbol: `USDbc`
- [BaseScan: 0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA](https://basescan.org/token/0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA)

### CERE
- Symbol: `CERE`
- [Etherscan: 0x9886447Ff4c350f4600E4BF95Db756Bdc629b1cA](https://basescan.org/token/0x9886447Ff4c350f4600E4BF95Db756Bdc629b1cA)

### QUICKSWAP
- Symbol: `QUICK`
- [Etherscan: 0x7094c27f342DBAdfbbeD005b219431595E33b305](https://basescan.org/token/0x7094c27f342DBAdfbbeD005b219431595E33b305)
