### PR TITLE
Chore: Adding retard, BasedPepe, MASQ, LINK, Aave, BRETT, RWA Inc, AIXBT, Virtual Protocol, Keeta on Base network

### DIFF
--- a/src/tokens/base.json
+++ b/src/tokens/base.json
@@ -80,5 +80,81 @@
     "decimals": 18,
     "chainId": 8453,
     "logoURI": "https://etherscan.io/token/images/quickswapnew_32.png"
+  },
+  {
+    "name": "retard",
+    "address": "0xFA1c790f96bDe6DfFfa2860b794A096E8d85Bb07",
+    "symbol": "RETARD",
+    "decimals": 18,
+    "chainId": 8453,
+    "logoURI": "https://dd.dexscreener.com/ds-data/tokens/base/0xfa1c790f96bde6dfffa2860b794a096e8d85bb07.png?size=lg&key=0385a9"
+  },
+  {
+    "name": "BasedPepe",
+    "address": "0x52b492a33E447Cdb854c7FC19F1e57E8BfA1777D",
+    "symbol": "BPEPE",
+    "decimals": 18,
+    "chainId": 8453,
+    "logoURI": "https://basedpepe.vip/logo.svg"
+  },
+  {
+    "name": "MASQ",
+    "address": "0x45D9C101a3870Ca5024582fd788F4E1e8F7971c3",
+    "symbol": "MASQ",
+    "decimals": 18,
+    "chainId": 8453,
+    "logoURI": "https://assets.coingecko.com/coins/images/13699/large/MASQ_Logo_Blue_Solo_Transparent.png?1616661801"
+  },
+  {
+    "name": "RWA Inc",
+    "address": "0xE2B1dc2D4A3b4E59FDF0c47B71A7A86391a8B35a",
+    "symbol": "RWA",
+    "decimals": 18,
+    "chainId": 8453
+  },
+  {
+    "name": "Chainlink",
+    "address": "0x88Fb150BDc53A65fe94Dea0c9BA0a6dAf8C6e196",
+    "symbol": "LINK",
+    "decimals": 18,
+    "chainId": 8453,
+    "logoURI": "https://assets.coingecko.com/coins/images/877/large/chainlink-new-logo.png?1547034700"
+  },
+  {
+    "name": "Aave",
+    "address": "0x63706e401c06ac8513145b7687A14804d17f814b",
+    "symbol": "AAVE",
+    "decimals": 18,
+    "chainId": 8453,
+    "logoURI": "https://assets.coingecko.com/coins/images/12645/large/AAVE.png?1601374110"
+  },
+  {
+    "name": "BRETT",
+    "address": "0x532f27101965dd16442E59d40670FaF5eBB142E4",
+    "symbol": "BRETT",
+    "decimals": 18,
+    "chainId": 8453,
+    "logoURI": "https://assets.coingecko.com/coins/images/30980/large/brett.png"
+  },
+  {
+    "name": "AIXBT",
+    "address": "0x4F9Fd6Be4a90f2620860d680c0d4d5Fb53d1A825",
+    "symbol": "AIXBT",
+    "decimals": 18,
+    "chainId": 8453
+  },
+  {
+    "name": "Virtual Protocol",
+    "address": "0x0b3e328455c4059EEb9e3f84b5543F74E24e7E1b",
+    "symbol": "VIRTUAL",
+    "decimals": 18,
+    "chainId": 8453
+  },
+  {
+    "name": "Keeta",
+    "address": "0xc0634090F2Fe6c6d75e61Be2b949464aBB498973",
+    "symbol": "KTA",
+    "decimals": 18,
+    "chainId": 8453
   }
 ]


### PR DESCRIPTION
## Tokens changed

### retard
- Symbol: `RETARD`
- [BaseScan: 0xFA1c790f96bDe6DfFfa2860b794A096E8d85Bb07](https://basescan.org/token/0xFA1c790f96bDe6DfFfa2860b794A096E8d85Bb07)

### BasedPepe
- Symbol: `BPEPE`
- [BaseScan: 0x52b492a33E447Cdb854c7FC19F1e57E8BfA1777D](https://basescan.org/token/0x52b492a33E447Cdb854c7FC19F1e57E8BfA1777D)

### MASQ
- Symbol: `MASQ`
- [BaseScan: 0x45D9C101a3870Ca5024582fd788F4E1e8F7971c3](https://basescan.org/token/0x45D9C101a3870Ca5024582fd788F4E1e8F7971c3)

### RWA Inc
- Symbol: `RWA`
- [BaseScan: 0xE2B1dc2D4A3b4E59FDF0c47B71A7A86391a8B35a](https://basescan.org/token/0xE2B1dc2D4A3b4E59FDF0c47B71A7A86391a8B35a)

### Chainlink
- Symbol: `LINK`
- [BaseScan: 0x88Fb150BDc53A65fe94Dea0c9BA0a6dAf8C6e196](https://basescan.org/token/0x88Fb150BDc53A65fe94Dea0c9BA0a6dAf8C6e196)

### Aave
- Symbol: `AAVE`
- [BaseScan: 0x63706e401c06ac8513145b7687A14804d17f814b](https://basescan.org/token/0x63706e401c06ac8513145b7687A14804d17f814b)

### BRETT
- Symbol: `BRETT`
- [BaseScan: 0x532f27101965dd16442E59d40670FaF5eBB142E4](https://basescan.org/token/0x532f27101965dd16442E59d40670FaF5eBB142E4)

### AIXBT
- Symbol: `AIXBT`
- [BaseScan: 0x4F9Fd6Be4a90f2620860d680c0d4d5Fb53d1A825](https://basescan.org/token/0x4F9Fd6Be4a90f2620860d680c0d4d5Fb53d1A825)

### Virtual Protocol
- Symbol: `VIRTUAL`
- [BaseScan: 0x0b3e328455c4059EEb9e3f84b5543F74E24e7E1b](https://basescan.org/token/0x0b3e328455c4059EEb9e3f84b5543F74E24e7E1b)

### Keeta
- Symbol: `KTA`
- [BaseScan: 0xc0634090F2Fe6c6d75e61Be2b949464aBB498973](https://basescan.org/token/0xc0634090F2Fe6c6d75e61Be2b949464aBB498973)