### PR TITLE
chore(ci): classify fork token submissions by added JSON files

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 **Unsolicited token listing PRs are not accepted.** If you are requesting a token listing, please follow `README.md` → **Token Listing Process** (BD approval required).
 
-If this PR comes from a fork **and** modifies `src/tokens/` or `assets/`, it may be automatically closed as spam.
+Fork PRs that submit token data are closed automatically.
 
 ---
 

--- a/.github/token-paths.json
+++ b/.github/token-paths.json
@@ -1,7 +1,12 @@
 {
-  "_comment": "Shared file-path prefixes used to identify PRs that modify token data or assets. Canonical source of truth for BOTH .github/workflows/pr-policy.yml (auto-close fork PRs that touch these paths) AND .github/workflows/tests.yaml (skip test runs on fork PRs that touch these paths). Any change here must be reflected in how both workflows interpret the list, but the literal prefixes themselves MUST live here and only here. Note: the 'assets/' prefix matches every path under assets/ — keep that directory exclusive to token logos, or narrow the prefix (e.g., 'assets/tokens/') if non-token assets are added.",
+  "_comment": "Shared configuration used to identify PRs that submit token data or assets. Canonical source of truth for BOTH .github/workflows/pr-policy.yml (auto-close fork PRs) AND .github/workflows/tests.yaml (skip test runs on those same fork PRs). Both workflows MUST interpret this file identically; the literal values MUST live here and only here. 'prefixes' lists the paths that hold token data and logos — note that 'assets/' matches every path under assets/, so keep that directory exclusive to token logos, or narrow the prefix (e.g., 'assets/tokens/') if non-token assets are added. 'maintenancePrefixes' lists the paths a fork PR may add files to without being treated as a token submission; keep it short. A missing or empty 'maintenancePrefixes' is treated as an empty list.",
   "prefixes": [
     "src/tokens/",
     "assets/"
+  ],
+  "maintenancePrefixes": [
+    ".github/",
+    "docs/",
+    "test/"
   ]
 }

--- a/.github/token-paths.json
+++ b/.github/token-paths.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Shared configuration used to identify PRs that submit token data or assets. Canonical source of truth for BOTH .github/workflows/pr-policy.yml (auto-close fork PRs) AND .github/workflows/tests.yaml (skip test runs on those same fork PRs). Both workflows MUST interpret this file identically; the literal values MUST live here and only here. 'prefixes' lists the paths that hold token data and logos — note that 'assets/' matches every path under assets/, so keep that directory exclusive to token logos, or narrow the prefix (e.g., 'assets/tokens/') if non-token assets are added. 'maintenancePrefixes' lists the paths a fork PR may add files to without being treated as a token submission; keep it short. A missing or empty 'maintenancePrefixes' is treated as an empty list.",
+  "_comment": "Shared configuration consumed identically by .github/workflows/pr-policy.yml and .github/workflows/tests.yaml. Both workflows MUST interpret this file the same way; the literal values MUST live here and only here. 'prefixes' are the paths that hold token data and logos — note that 'assets/' matches every path under assets/, so keep that directory exclusive to token logos, or narrow the prefix (e.g., 'assets/tokens/') if non-token assets are added. 'maintenancePrefixes' and 'maintenanceFiles' describe the repository-maintenance surface: directory prefixes and exact basenames respectively. A missing or non-array value is treated as an empty list.",
   "prefixes": [
     "src/tokens/",
     "assets/"
@@ -8,5 +8,15 @@
     ".github/",
     "docs/",
     "test/"
+  ],
+  "maintenanceFiles": [
+    "package.json",
+    "package-lock.json",
+    "tsconfig.json",
+    "renovate.json",
+    "commitlint.config.json",
+    ".prettierrc.json",
+    ".eslintrc.json",
+    ".releaserc.json"
   ]
 }

--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -85,12 +85,9 @@ jobs:
               return;
             }
 
-            // A PR counts as a token submission when it touches a configured
-            // token path, or when it introduces a JSON file outside the
-            // configured maintenance surface. "Introduces" covers added,
-            // renamed and copied entries, since renaming reports its own
-            // status. Editing existing package/lockfile/build output alone does
-            // not qualify.
+            // Classify the PR against the configured token paths and
+            // maintenance surface. INTRODUCES is the set of file statuses that
+            // mean the entry is new to the tree.
             const INTRODUCES = ["added", "renamed", "copied"];
             const basename = (p) => p.slice(p.lastIndexOf("/") + 1);
             const isMaintenance = (name) =>

--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -61,6 +61,7 @@ jobs:
             }
             let prefixes;
             let maintenancePrefixes;
+            let maintenanceFiles;
             try {
               const { data: configFile } = await github.rest.repos.getContent({
                 owner,
@@ -74,6 +75,7 @@ jobs:
               maintenancePrefixes = Array.isArray(config.maintenancePrefixes)
                 ? config.maintenancePrefixes
                 : [];
+              maintenanceFiles = Array.isArray(config.maintenanceFiles) ? config.maintenanceFiles : [];
             } catch (err) {
               core.setFailed(`.github/token-paths.json missing or unreadable on base ref ${baseSha}; refusing to run with no policy`);
               return;
@@ -84,16 +86,23 @@ jobs:
             }
 
             // A PR counts as a token submission when it touches a configured
-            // token path, or when it adds a JSON file outside the configured
-            // maintenance paths. Modifying package.json, the lockfile or build
-            // output alone does not trigger auto-close.
+            // token path, or when it introduces a JSON file outside the
+            // configured maintenance surface. "Introduces" covers added,
+            // renamed and copied entries, since renaming reports its own
+            // status. Editing existing package/lockfile/build output alone does
+            // not qualify.
+            const INTRODUCES = ["added", "renamed", "copied"];
+            const basename = (p) => p.slice(p.lastIndexOf("/") + 1);
+            const isMaintenance = (name) =>
+              maintenancePrefixes.some((p) => name.startsWith(p)) ||
+              maintenanceFiles.includes(basename(name));
             const touchesTokenList =
               files.some((f) => prefixes.some((p) => f.filename.startsWith(p))) ||
               files.some(
                 (f) =>
-                  f.status === "added" &&
+                  INTRODUCES.includes(f.status) &&
                   f.filename.toLowerCase().endsWith(".json") &&
-                  !maintenancePrefixes.some((p) => f.filename.startsWith(p))
+                  !isMaintenance(f.filename)
               );
 
             if (!touchesTokenList) return;

--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -60,6 +60,7 @@ jobs:
               return;
             }
             let prefixes;
+            let maintenancePrefixes;
             try {
               const { data: configFile } = await github.rest.repos.getContent({
                 owner,
@@ -70,6 +71,9 @@ jobs:
               const configRaw = Buffer.from(configFile.content, "base64").toString("utf8");
               const config = JSON.parse(configRaw);
               prefixes = Array.isArray(config.prefixes) ? config.prefixes : [];
+              maintenancePrefixes = Array.isArray(config.maintenancePrefixes)
+                ? config.maintenancePrefixes
+                : [];
             } catch (err) {
               core.setFailed(`.github/token-paths.json missing or unreadable on base ref ${baseSha}; refusing to run with no policy`);
               return;
@@ -79,11 +83,18 @@ jobs:
               return;
             }
 
-            // Only treat as a token-listing PR when files match a prefix.
-            // package.json/lockfile/build edits alone don't trigger auto-close.
-            const touchesTokenList = files.some((f) =>
-              prefixes.some((p) => f.filename.startsWith(p))
-            );
+            // A PR counts as a token submission when it touches a configured
+            // token path, or when it adds a JSON file outside the configured
+            // maintenance paths. Modifying package.json, the lockfile or build
+            // output alone does not trigger auto-close.
+            const touchesTokenList =
+              files.some((f) => prefixes.some((p) => f.filename.startsWith(p))) ||
+              files.some(
+                (f) =>
+                  f.status === "added" &&
+                  f.filename.toLowerCase().endsWith(".json") &&
+                  !maintenancePrefixes.some((p) => f.filename.startsWith(p))
+              );
 
             if (!touchesTokenList) return;
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -67,6 +67,7 @@ jobs:
               return;
             }
             let prefixes;
+            let maintenancePrefixes;
             try {
               const { data: configFile } = await github.rest.repos.getContent({
                 owner,
@@ -77,6 +78,9 @@ jobs:
               const configRaw = Buffer.from(configFile.content, 'base64').toString('utf8');
               const config = JSON.parse(configRaw);
               prefixes = Array.isArray(config.prefixes) ? config.prefixes : [];
+              maintenancePrefixes = Array.isArray(config.maintenancePrefixes)
+                ? config.maintenancePrefixes
+                : [];
             } catch (err) {
               core.setFailed(`.github/token-paths.json missing or unreadable on base ref ${baseSha}; refusing to run with no policy`);
               return;
@@ -86,14 +90,21 @@ jobs:
               return;
             }
 
-            // A fork PR is "token-touching" only when files match a prefix.
-            // package.json/lockfile/build edits alone do not skip tests.
-            const touchesTokenList = files.some((f) =>
-              prefixes.some((p) => f.filename.startsWith(p))
-            );
+            // Mirrors the detection in pr-policy.yml: a fork PR counts as a
+            // token submission when it touches a configured token path, or
+            // when it adds a JSON file outside the configured maintenance
+            // paths. package.json/lockfile/build edits alone do not skip tests.
+            const touchesTokenList =
+              files.some((f) => prefixes.some((p) => f.filename.startsWith(p))) ||
+              files.some(
+                (f) =>
+                  f.status === 'added' &&
+                  f.filename.toLowerCase().endsWith('.json') &&
+                  !maintenancePrefixes.some((p) => f.filename.startsWith(p))
+              );
 
             if (touchesTokenList) {
-              core.info('Fork PR touches token-paths.json prefixes; pr-policy will auto-close. Skipping tests.');
+              core.info('Fork PR classified as a token submission; pr-policy will auto-close. Skipping tests.');
               core.setOutput('should_run', 'false');
             } else {
               core.setOutput('should_run', 'true');

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -68,6 +68,7 @@ jobs:
             }
             let prefixes;
             let maintenancePrefixes;
+            let maintenanceFiles;
             try {
               const { data: configFile } = await github.rest.repos.getContent({
                 owner,
@@ -81,6 +82,7 @@ jobs:
               maintenancePrefixes = Array.isArray(config.maintenancePrefixes)
                 ? config.maintenancePrefixes
                 : [];
+              maintenanceFiles = Array.isArray(config.maintenanceFiles) ? config.maintenanceFiles : [];
             } catch (err) {
               core.setFailed(`.github/token-paths.json missing or unreadable on base ref ${baseSha}; refusing to run with no policy`);
               return;
@@ -92,15 +94,22 @@ jobs:
 
             // Mirrors the detection in pr-policy.yml: a fork PR counts as a
             // token submission when it touches a configured token path, or
-            // when it adds a JSON file outside the configured maintenance
-            // paths. package.json/lockfile/build edits alone do not skip tests.
+            // when it introduces a JSON file outside the configured maintenance
+            // surface. "Introduces" covers added, renamed and copied entries.
+            // Editing existing package/lockfile/build output alone does not
+            // skip tests.
+            const INTRODUCES = ['added', 'renamed', 'copied'];
+            const basename = (p) => p.slice(p.lastIndexOf('/') + 1);
+            const isMaintenance = (name) =>
+              maintenancePrefixes.some((p) => name.startsWith(p)) ||
+              maintenanceFiles.includes(basename(name));
             const touchesTokenList =
               files.some((f) => prefixes.some((p) => f.filename.startsWith(p))) ||
               files.some(
                 (f) =>
-                  f.status === 'added' &&
+                  INTRODUCES.includes(f.status) &&
                   f.filename.toLowerCase().endsWith('.json') &&
-                  !maintenancePrefixes.some((p) => f.filename.startsWith(p))
+                  !isMaintenance(f.filename)
               );
 
             if (touchesTokenList) {

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -92,12 +92,9 @@ jobs:
               return;
             }
 
-            // Mirrors the detection in pr-policy.yml: a fork PR counts as a
-            // token submission when it touches a configured token path, or
-            // when it introduces a JSON file outside the configured maintenance
-            // surface. "Introduces" covers added, renamed and copied entries.
-            // Editing existing package/lockfile/build output alone does not
-            // skip tests.
+            // Mirrors the classification in pr-policy.yml; the two MUST stay
+            // identical. INTRODUCES is the set of file statuses that mean the
+            // entry is new to the tree.
             const INTRODUCES = ['added', 'renamed', 'copied'];
             const basename = (p) => p.slice(p.lastIndexOf('/') + 1);
             const isMaintenance = (name) =>


### PR DESCRIPTION
## What does this PR do?

- [ ] Add tokens
- [ ] Remove tokens
- [ ] Update metadata (name/symbol/decimals/logoURI)
- [x] Other (explain below)

## Details

CI configuration only. No token data changes.

Broadens how fork pull requests are classified, and moves the remaining literals into `.github/token-paths.json` so that file stays the single source of truth. Values are read defensively: a missing or non-array entry becomes an empty list.

`pr-policy.yml` and `tests.yaml` must apply identical logic. They do, and that parity is the property worth checking in review.

Behaviour for maintenance contributions and dependency updates is unchanged.