### PR TITLE
fix(schema): validate token list against the schema the app enforces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@ethersproject/address": "5.7.0",
-        "@uniswap/token-lists": "1.0.0-beta.33",
+        "@uniswap/token-lists": "npm:quickswap-token-lists@^1.0.2",
         "ajv": "6.14.0",
         "chai": "4.5.0",
         "mocha": "11.7.2",
@@ -176,9 +176,10 @@
       }
     },
     "node_modules/@uniswap/token-lists": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/@uniswap/token-lists/-/token-lists-1.0.0-beta.33.tgz",
-      "integrity": "sha512-JQkXcpRI3jFG8y3/CGC4TS8NkDgcxXaOQuYW8Qdvd6DcDiIyg2vVYCG9igFEzF0G6UvxgHkBKC7cWCgzZNYvQg==",
+      "name": "quickswap-token-lists",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/quickswap-token-lists/-/quickswap-token-lists-1.0.2.tgz",
+      "integrity": "sha512-4eEmQLg+OAhV3veZOFghtl9lKhFxXgijk/JSwExjE9HkKr1U1SvzmM0lVxf+krZYRIKT3SYb0KnlmP/Z2Q/m8w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -685,19 +686,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
-      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/has-flag": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://quickswap.exchange",
   "devDependencies": {
     "@ethersproject/address": "5.7.0",
-    "@uniswap/token-lists": "1.0.0-beta.33",
+    "@uniswap/token-lists": "npm:quickswap-token-lists@^1.0.2",
     "ajv": "6.14.0",
     "chai": "4.5.0",
     "mocha": "11.7.2",

--- a/test/uniswap-default.test.js
+++ b/test/uniswap-default.test.js
@@ -2,13 +2,28 @@ const packageJson = require('../package.json');
 const { expect } = require('chai');
 const { getAddress } = require('@ethersproject/address');
 const Ajv = require('ajv');
+const schema = require('@uniswap/token-lists/src/tokenlist.schema.json');
 const buildList = require('../src/buildList');
 
 const ajv = new Ajv({ allErrors: true, format: 'full' });
+const validate = ajv.compile(schema);
+// Local list-level cap, kept in addition to the schema check: the schema
+// dependency resolves to a package outside this repo, so a widened upstream
+// maxLength would silently loosen this assertion too. This value must never
+// be raised without confirming it against the schema the app enforces.
+const LIST_NAME_MAX_LENGTH = 20;
 
 describe('buildList', () => {
   const defaultTokenList = buildList();
 
+  it('conforms to the token list schema', () => {
+    const valid = validate(defaultTokenList);
+    expect(valid, ajv.errorsText(validate.errors, { separator: '\n' })).to.equal(true);
+  });
+
+  it('list name does not exceed the schema-enforced maximum length', () => {
+    expect(defaultTokenList.name.length).to.be.at.most(LIST_NAME_MAX_LENGTH);
+  });
 
   it('contains no duplicate addresses', () => {
     const map = {};


### PR DESCRIPTION
## What does this PR do?

- [ ] Add tokens
- [ ] Remove tokens
- [ ] Update metadata (name/symbol/decimals/logoURI)
- [x] Other (explain below)

## Details

The schema devDependency now points at the same package the consuming app resolves, so the list is checked against the same contract it will be read under.

`test/uniswap-default.test.js` compiles that schema and asserts the built list, and every token in it, conforms. A second assertion keeps the list name within the schema's length limit — the current name sits exactly at the maximum, so there is no headroom.

No token data changed. Addresses, symbols, names, decimals and logos are untouched.

The lockfile diff includes one entry dropped by npm's dependency-graph recompute, reachable only through the previous resolution. The existing `overrides` block is unchanged and `npm audit` still reports no vulnerabilities.