### PR TITLE
chore(deps): bump js-yaml and brace-expansion overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -267,9 +267,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -791,9 +791,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.3.tgz",
+      "integrity": "sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==",
       "dev": true,
       "funding": [
         {
@@ -810,7 +810,7 @@
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/json-schema-traverse": {

--- a/package.json
+++ b/package.json
@@ -41,14 +41,14 @@
     "bn.js": "5.2.3",
     "diff": "8.0.3",
     "minimatch": "10.2.4",
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "5.0.9",
     "serialize-javascript": "7.0.5",
     "rimraf": {
       "glob": {
         "minimatch": "3.1.4"
       }
     },
-    "js-yaml": "4.3.0"
+    "js-yaml": "5.2.3"
   },
   "engines": {
     "node": ">=18.0.0",


### PR DESCRIPTION
## What does this PR do?

- [ ] Add tokens
- [ ] Remove tokens
- [ ] Update metadata (name/symbol/decimals/logoURI)
- [x] Other (explain below)

## Details

Bump two dependency overrides to their current patched releases:

| Override | Before | After |
|---|---|---|
| `brace-expansion` | `5.0.8` | `5.0.9` |
| `js-yaml` | `4.3.0` | `5.2.3` |

Both are transitive devDependencies. No runtime dependencies change and the published output is unaffected.
